### PR TITLE
Adjust homepage hero logo placement and header logo size

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,18 +24,22 @@
 
   <main>
     <section class="hero container">
-      <p class="eyebrow">INDIE GAME STUDIO</p>
-      <h1>Minimal games.<br />Bold identity.</h1>
-      <p class="hero-text">
-        HumpbackWhale Games is a developer of focused, stylish indie projects with clean presentation and strong gameplay mechanics.
-      </p>
-      <div class="hero-actions">
-        <a href="games.html" class="btn btn-accent">View Games</a>
-        <a href="about.html" class="btn btn-secondary">About the Studio</a>
-      </div>
+      <div class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">INDIE GAME STUDIO</p>
+          <h1>Minimal games.<br />Bold identity.</h1>
+          <p class="hero-text">
+            HumpbackWhale Games is a developer of focused, stylish indie projects with clean presentation and strong gameplay mechanics.
+          </p>
+          <div class="hero-actions">
+            <a href="games.html" class="btn btn-accent">View Games</a>
+            <a href="about.html" class="btn btn-secondary">About the Studio</a>
+          </div>
+        </div>
 
-      <div class="hero-art">
-        <img src="images/hwg-logo.png" alt="HumpbackWhale Games logo" class="hero-logo" />
+        <div class="hero-art">
+          <img src="images/hwg-logo.png" alt="HumpbackWhale Games logo" class="hero-logo" />
+        </div>
       </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -57,7 +57,7 @@ img {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-height: 72px;
+  min-height: 84px;
   gap: 1rem;
 }
 
@@ -71,8 +71,8 @@ img {
 }
 
 .logo-mark {
-  width: 30px;
-  height: 30px;
+  width: 64px;
+  height: 64px;
   object-fit: contain;
   display: block;
   flex-shrink: 0;
@@ -350,17 +350,16 @@ h2 {
   }
 
   .hero-grid {
-  grid-template-columns: 1fr;
-  gap: 2rem;
-}
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
 
-.hero-art {
-  justify-content: flex-start;
-}
+  .hero-art {
+    justify-content: flex-start;
+  }
 
-.hero-logo {
-  max-width: 220px;
-  max-height: 220px;
-}
+  .hero-logo {
+    max-width: 220px;
+    max-height: 220px;
   }
 }


### PR DESCRIPTION
### Motivation
- Improve the homepage hero layout so the large HWG logo appears to the right of the “Minimal games / Bold identity” copy instead of dropping below the CTA links.
- Balance header spacing by enlarging the small header mark so the branding reads clearer at a glance.
- Preserve existing responsive behavior so the hero stacks on small screens.

### Description
- Wrapped the hero copy and CTAs in a `div.hero-grid` and added `div.hero-copy` / `div.hero-art` around the text and logo respectively in `index.html` so the large logo sits beside the headline.
- Increased the header mark size by setting `.logo-mark` to `64px × 64px` and bumped `.nav-wrap` `min-height` to `84px` in `style.css` to keep vertical spacing balanced.
- Kept the mobile breakpoint behavior by preserving the `@media (max-width: 800px)` rules so the hero collapses to a single column on small screens.
- Cleaned up the media-query block formatting in `style.css` while updating hero-related rules.

### Testing
- Ran `git diff --check` to ensure no whitespace/merge issues, which completed successfully.
- Served the site locally with `python -m http.server` and visually verified the hero and header layout, which displayed as expected.
- Captured a Playwright screenshot of `http://127.0.0.1:4173/index.html` showing the updated hero placement, which confirmed the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af6e2d0518832983ece6bc899027d5)