### PR TITLE
Mobile: Move hero logo below CTA links

### DIFF
--- a/style.css
+++ b/style.css
@@ -350,11 +350,18 @@ h2 {
   }
 
   .hero-grid {
-    grid-template-columns: 1fr;
-    gap: 2rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.25rem;
+  }
+
+  .hero-copy {
+    width: 100%;
   }
 
   .hero-art {
+    order: 2;
     justify-content: flex-start;
   }
 


### PR DESCRIPTION
### Motivation
- Ensure on narrow screens the hero logo appears below the “View Games / About the Studio” CTAs while preserving the desktop layout.

### Description
- Modified `style.css` mobile rules (`@media (max-width: 800px)`) to make `.hero-grid` a vertical flex column, set `.hero-copy` to `width: 100%`, and set `.hero-art` `order: 2` so the logo renders after the CTAs; adjusted spacing accordingly (file changed: `style.css`).
- Skills used: none.

### Testing
- Started a local server with `python3 -m http.server 4173` and captured a mobile viewport screenshot via Playwright (`390x844`) which verified the logo is below the CTAs; automated checks and commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a77215d48329a7b64496581950f8)