### PR TITLE
Add Tabletop Touchdown privacy policy page and link from project page

### DIFF
--- a/tabletop-touchdown-privacy-policy.html
+++ b/tabletop-touchdown-privacy-policy.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tabletop Touchdown Privacy Policy | HumpbackWhale Games</title>
+  <meta name="description" content="Privacy policy for Tabletop Touchdown." />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body class="theme-game">
+  <header class="site-header">
+    <div class="container nav-wrap">
+      <a href="index.html" class="logo">
+        <img src="images/hwg-logo.png" alt="HumpbackWhale Games logo" class="logo-mark" />
+        <span>HumpbackWhale Games</span>
+      </a>
+      <nav class="nav">
+        <a href="index.html">Home</a>
+        <a href="about.html">About</a>
+        <a href="games.html">Games</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container page-main">
+    <p class="eyebrow">TABLETOP TOUCHDOWN</p>
+    <h1 class="page-title">Privacy Policy</h1>
+
+    <div class="content-block">
+      <p>
+        This privacy policy explains how Tabletop Touchdown handles user information.
+      </p>
+      <p>
+        At this time, Tabletop Touchdown does not collect personal information directly through this website.
+      </p>
+      <p>
+        If data collection features are added in the future, this page will be updated with details on what is collected, how it is used, and contact information for privacy requests.
+      </p>
+    </div>
+
+    <a href="tabletop-touchdown.html" class="btn btn-secondary">Back to Tabletop Touchdown</a>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-wrap">
+      <p>© 2026 HumpbackWhale Games</p>
+      <p>Tabletop Touchdown privacy policy</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/tabletop-touchdown.html
+++ b/tabletop-touchdown.html
@@ -39,7 +39,7 @@
         <p class="card-label">PROJECT STYLE</p>
         <h2>Green accent identity</h2>
         <p>
-          
+
         </p>
       </article>
 
@@ -47,7 +47,7 @@
         <p class="card-label">OVERVIEW</p>
         <h2>Built for focus</h2>
         <p>
-          
+
         </p>
       </article>
     </section>
@@ -56,6 +56,16 @@
       <div class="feature-banner">
         <p class="feature-label">NEXT STEP</p>
         <h2>Add screenshots, gameplay details, and launch information here.</h2>
+      </div>
+    </section>
+
+    <section class="container section">
+      <div class="feature-banner">
+        <p class="feature-label">PRIVACY POLICY</p>
+        <h2>
+          Read the Tabletop Touchdown privacy policy
+          <a href="tabletop-touchdown-privacy-policy.html" class="text-link">here</a>.
+        </h2>
       </div>
     </section>
   </main>


### PR DESCRIPTION
### Motivation
- Add a dedicated privacy policy for the Tabletop Touchdown project and surface it from the project page to inform users about data handling and future changes.

### Description
- Added `tabletop-touchdown-privacy-policy.html` with a basic privacy statement and updated `tabletop-touchdown.html` to include a `PRIVACY POLICY` section linking to the new page, plus minor whitespace cleanup in existing paragraphs.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0abd65bf88329b57519027260654d)