### PR TITLE
Improve Tabletop Touchdown privacy policy formatting

### DIFF
--- a/style.css
+++ b/style.css
@@ -268,6 +268,34 @@ h2 {
   margin-bottom: 2rem;
 }
 
+
+.privacy-policy h2 {
+  margin-top: 1.9rem;
+  margin-bottom: 0.6rem;
+  font-size: clamp(1.2rem, 2.2vw, 1.6rem);
+}
+
+.privacy-policy h3 {
+  margin-top: 1.3rem;
+  margin-bottom: 0.5rem;
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+}
+
+.privacy-policy p {
+  margin-bottom: 0.9rem;
+}
+
+.privacy-policy ul {
+  margin: 0 0 1rem 1.25rem;
+  padding: 0;
+  color: var(--muted);
+}
+
+.privacy-policy li {
+  margin-bottom: 0.4rem;
+}
+
 .game-card {
   display: flex;
   align-items: center;

--- a/tabletop-touchdown-privacy-policy.html
+++ b/tabletop-touchdown-privacy-policy.html
@@ -26,188 +26,132 @@
     <p class="eyebrow">TABLETOP TOUCHDOWN</p>
     <h1 class="page-title">Privacy Policy</h1>
 
-    <div class="content-block">
-      <p>
-        This privacy policy explains how Tabletop Touchdown handles user information.
-      </p>
-      <p>
-        Effective Date: 3/1/26
-Developer: HumpbackWhale Games
-Contact: humpbackwhalegames@gmail.com
-
-HumpbackWhale Games (“we,” “us,” or “our”) operates the mobile game Tabletop Touchdown (the “App”). This Privacy Policy explains what information may be collected when you use the App, how it is used, how it may be shared, and what choices you may have.
-
-1. Information We Collect
-A. Information stored locally on your device
-
-The App stores certain game data locally on your device so that your progress and gameplay state can be saved and restored.
-
-This information is stored locally on your device using the App’s local storage, and is deleted when the app is uninstalled.
-
-B. Advertising and mediation-related information
-
-The App uses third-party advertising and ad mediation services. These services may collect, receive, or process certain information in connection with ad delivery, ad measurement, monetization, fraud prevention, and related operations.
-
-This information may include:
-
-advertising identifiers, such as Android Advertising ID
-
-device identifiers and device information
-
-IP address
-
-approximate location derived from IP address
-
-app usage and ad interaction data
-
-ad request, impression, and engagement data
-
-diagnostic and performance data
-
-In connection with advertising, the App and/or integrated SDKs may also process ad-related metadata such as:
-
-ad unit identifiers
-
-ad network name
-
-mediation instance information
-
-ad revenue or revenue-related reporting information
-
-C. Diagnostic and technical information
-
-The App and its third-party SDKs may collect limited technical, diagnostic, or crash-related information to help maintain functionality, troubleshoot issues, and improve stability.
-
-This may include:
-
-app version
-
-operating system
-
-device type
-
-crash logs
-
-performance diagnostics
-
-2. How We Use Information
-
-We may use information collected through the App to:
-
-provide and operate the App
-
-save and restore gameplay progress
-
-deliver advertisements
-
-measure ad performance and monetization
-
-prevent fraud, invalid traffic, and abuse
-
-troubleshoot crashes and technical issues
-
-improve app stability, functionality, and user experience
-
-comply with legal obligations
-
-3. Third-Party Advertising Services
-
-The App uses third-party SDKs and services for advertisements, such as LevelPlay and Unity Ads.
-
-These third parties may collect, use, and share information in accordance with their own privacy policies and applicable law.
-
-4. Advertising
-
-The App may display advertisements during gameplay, including interstitial ads. These ads may be delivered through ad mediation services that work with multiple advertising networks.
-
-Advertising partners may use collected information to:
-
-provide ads
-
-measure ad performance
-
-manage ad frequency
-
-prevent fraud and invalid traffic
-
-support monetization and reporting
-
-Depending on your device settings, region, and applicable law, ads shown in the App may be personalized or non-personalized.
-
-You may be able to manage advertising preferences through your device settings, including resetting or limiting use of your advertising identifier where supported.
-
-5. Data Sharing
-
-We do not sell personal information. However, we may share information with third-party service providers and partners that help us operate and monetize the App, including:
-
-advertising and mediation providers
-
-analytics, diagnostic, and crash-related service providers used through integrated SDKs
-
-platform providers such as Google Play and Unity-related services
-
-legal authorities when required by law or when necessary to protect our rights, users, or services
-
-6. Data Retention and Deletion
-Local data on your device
-
-Gameplay save data stored locally on your device remains there until it is removed.
-
-You can generally delete locally stored game data by:
-
-uninstalling the App, and/or
-
-clearing the App’s storage/data through your device settings
-
-Third-party SDK data
-
-Information collected by third-party SDKs may be retained according to those providers’ own retention practices and legal requirements.
-
-7. Accounts and Direct User Collection
-
-The App does not require user account creation, login, or direct submission of personal information to use core gameplay features.
-
-We also do not intentionally collect email addresses or other direct user contact information through the App itself, unless you separately contact us for support.
-
-8. Children’s Privacy
-
-The App is intended for a general audience unless otherwise stated in the applicable app store listing. We do not knowingly collect personal information directly from children in violation of applicable law.
-
-Because the App may use advertising SDKs, additional restrictions or protections may apply depending on your region, device settings, and platform requirements.
-
-9. Your Rights and Choices
-
-Depending on your jurisdiction, you may have rights regarding personal information, including rights to request access, deletion, correction, or restriction of certain processing.
-
-You may also have choices regarding:
-
-your device advertising settings
-
-resetting your advertising identifier
-
-deleting local save data by clearing app storage or uninstalling the App
-
-To make a privacy-related request, contact us at [your support email].
-
-10. International Processing
-
-Third-party services used by the App may process information in countries other than your own. By using the App, you understand that information may be processed in jurisdictions that may have different data protection laws than your own.
-
-11. Security
-
-We use reasonable measures to help protect information related to the App. However, no method of electronic storage or transmission is completely secure, and we cannot guarantee absolute security.
-
-12. Changes to This Privacy Policy
-
-We may update this Privacy Policy from time to time. When we do, we will revise the Effective Date above. Your continued use of the App after any update becomes effective constitutes acceptance of the revised Privacy Policy.
-
-13. Contact Us
-
-If you have questions about this Privacy Policy or the App’s data practices, contact:
-
-HumpbackWhale Games
-Email: humpbackwhalegames@gmail.com
-      </p>
+    <div class="content-block privacy-policy">
+      <p>This privacy policy explains how Tabletop Touchdown handles user information.</p>
+      <p><strong>Effective Date:</strong> 3/1/26<br />
+      <strong>Developer:</strong> HumpbackWhale Games<br />
+      <strong>Contact:</strong> <a href="mailto:humpbackwhalegames@gmail.com" class="text-link">humpbackwhalegames@gmail.com</a></p>
+
+      <p>HumpbackWhale Games (“we,” “us,” or “our”) operates the mobile game Tabletop Touchdown (the “App”). This Privacy Policy explains what information may be collected when you use the App, how it is used, how it may be shared, and what choices you may have.</p>
+
+      <h2>1. Information We Collect</h2>
+      <h3>A. Information stored locally on your device</h3>
+      <p>The App stores certain game data locally on your device so that your progress and gameplay state can be saved and restored.</p>
+      <p>This information is stored locally on your device using the App’s local storage, and is deleted when the app is uninstalled.</p>
+
+      <h3>B. Advertising and mediation-related information</h3>
+      <p>The App uses third-party advertising and ad mediation services. These services may collect, receive, or process certain information in connection with ad delivery, ad measurement, monetization, fraud prevention, and related operations.</p>
+      <p>This information may include:</p>
+      <ul>
+        <li>Advertising identifiers, such as Android Advertising ID.</li>
+        <li>Device identifiers and device information.</li>
+        <li>IP address.</li>
+        <li>Approximate location derived from IP address.</li>
+        <li>App usage and ad interaction data.</li>
+        <li>Ad request, impression, and engagement data.</li>
+        <li>Diagnostic and performance data.</li>
+      </ul>
+      <p>In connection with advertising, the App and/or integrated SDKs may also process ad-related metadata such as:</p>
+      <ul>
+        <li>Ad unit identifiers.</li>
+        <li>Ad network name.</li>
+        <li>Mediation instance information.</li>
+        <li>Ad revenue or revenue-related reporting information.</li>
+      </ul>
+
+      <h3>C. Diagnostic and technical information</h3>
+      <p>The App and its third-party SDKs may collect limited technical, diagnostic, or crash-related information to help maintain functionality, troubleshoot issues, and improve stability.</p>
+      <p>This may include:</p>
+      <ul>
+        <li>App version.</li>
+        <li>Operating system.</li>
+        <li>Device type.</li>
+        <li>Crash logs.</li>
+        <li>Performance diagnostics.</li>
+      </ul>
+
+      <h2>2. How We Use Information</h2>
+      <p>We may use information collected through the App to:</p>
+      <ul>
+        <li>Provide and operate the App.</li>
+        <li>Save and restore gameplay progress.</li>
+        <li>Deliver advertisements.</li>
+        <li>Measure ad performance and monetization.</li>
+        <li>Prevent fraud, invalid traffic, and abuse.</li>
+        <li>Troubleshoot crashes and technical issues.</li>
+        <li>Improve app stability, functionality, and user experience.</li>
+        <li>Comply with legal obligations.</li>
+      </ul>
+
+      <h2>3. Third-Party Advertising Services</h2>
+      <p>The App uses third-party SDKs and services for advertisements, such as LevelPlay and Unity Ads.</p>
+      <p>These third parties may collect, use, and share information in accordance with their own privacy policies and applicable law.</p>
+
+      <h2>4. Advertising</h2>
+      <p>The App may display advertisements during gameplay, including interstitial ads. These ads may be delivered through ad mediation services that work with multiple advertising networks.</p>
+      <p>Advertising partners may use collected information to:</p>
+      <ul>
+        <li>Provide ads.</li>
+        <li>Measure ad performance.</li>
+        <li>Manage ad frequency.</li>
+        <li>Prevent fraud and invalid traffic.</li>
+        <li>Support monetization and reporting.</li>
+      </ul>
+      <p>Depending on your device settings, region, and applicable law, ads shown in the App may be personalized or non-personalized.</p>
+      <p>You may be able to manage advertising preferences through your device settings, including resetting or limiting use of your advertising identifier where supported.</p>
+
+      <h2>5. Data Sharing</h2>
+      <p>We do not sell personal information. However, we may share information with third-party service providers and partners that help us operate and monetize the App, including:</p>
+      <ul>
+        <li>Advertising and mediation providers.</li>
+        <li>Analytics, diagnostic, and crash-related service providers used through integrated SDKs.</li>
+        <li>Platform providers such as Google Play and Unity-related services.</li>
+        <li>Legal authorities when required by law or when necessary to protect our rights, users, or services.</li>
+      </ul>
+
+      <h2>6. Data Retention and Deletion</h2>
+      <h3>Local data on your device</h3>
+      <p>Gameplay save data stored locally on your device remains there until it is removed.</p>
+      <p>You can generally delete locally stored game data by:</p>
+      <ul>
+        <li>Uninstalling the App, and/or</li>
+        <li>Clearing the App’s storage/data through your device settings.</li>
+      </ul>
+
+      <h3>Third-party SDK data</h3>
+      <p>Information collected by third-party SDKs may be retained according to those providers’ own retention practices and legal requirements.</p>
+
+      <h2>7. Accounts and Direct User Collection</h2>
+      <p>The App does not require user account creation, login, or direct submission of personal information to use core gameplay features.</p>
+      <p>We also do not intentionally collect email addresses or other direct user contact information through the App itself, unless you separately contact us for support.</p>
+
+      <h2>8. Children’s Privacy</h2>
+      <p>The App is intended for a general audience unless otherwise stated in the applicable app store listing. We do not knowingly collect personal information directly from children in violation of applicable law.</p>
+      <p>Because the App may use advertising SDKs, additional restrictions or protections may apply depending on your region, device settings, and platform requirements.</p>
+
+      <h2>9. Your Rights and Choices</h2>
+      <p>Depending on your jurisdiction, you may have rights regarding personal information, including rights to request access, deletion, correction, or restriction of certain processing.</p>
+      <p>You may also have choices regarding:</p>
+      <ul>
+        <li>Your device advertising settings.</li>
+        <li>Resetting your advertising identifier.</li>
+        <li>Deleting local save data by clearing app storage or uninstalling the App.</li>
+      </ul>
+      <p>To make a privacy-related request, contact us at <a href="mailto:humpbackwhalegames@gmail.com" class="text-link">humpbackwhalegames@gmail.com</a>.</p>
+
+      <h2>10. International Processing</h2>
+      <p>Third-party services used by the App may process information in countries other than your own. By using the App, you understand that information may be processed in jurisdictions that may have different data protection laws than your own.</p>
+
+      <h2>11. Security</h2>
+      <p>We use reasonable measures to help protect information related to the App. However, no method of electronic storage or transmission is completely secure, and we cannot guarantee absolute security.</p>
+
+      <h2>12. Changes to This Privacy Policy</h2>
+      <p>We may update this Privacy Policy from time to time. When we do, we will revise the Effective Date above. Your continued use of the App after any update becomes effective constitutes acceptance of the revised Privacy Policy.</p>
+
+      <h2>13. Contact Us</h2>
+      <p>If you have questions about this Privacy Policy or the App’s data practices, contact:</p>
+      <p>HumpbackWhale Games<br />
+      Email: <a href="mailto:humpbackwhalegames@gmail.com" class="text-link">humpbackwhalegames@gmail.com</a></p>
     </div>
 
     <a href="tabletop-touchdown.html" class="btn btn-secondary">Back to Tabletop Touchdown</a>


### PR DESCRIPTION
### Motivation
- Make the long, unstructured privacy policy easier to read and scan by converting the raw text block into semantic HTML sections and lists.
- Replace plain-text contact mentions with clickable `mailto:` links to improve usability and correctness.
- Add page-specific CSS to ensure consistent spacing and typography for the policy content.

### Description
- Rewrote the policy content in `tabletop-touchdown-privacy-policy.html` into a `div` with class `privacy-policy` and structured the content using `h2`/`h3` headings, paragraphs, and unordered lists to preserve the original text while improving readability.
- Replaced plain email text and placeholder contact lines with `mailto:` links (`humpbackwhalegames@gmail.com`) in the header, rights section, and contact section.
- Added CSS rules in `style.css` under the `.privacy-policy` selector to adjust heading spacing, paragraph rhythm, and list styling so the new markup renders cleanly.
- Preserved all original policy content and page layout; this change is content and presentation only with no behavioral changes.

### Testing
- Started a local static server with `python -m http.server 4173` and confirmed the page served successfully.
- Ran an automated Playwright script to load `http://127.0.0.1:4173/tabletop-touchdown-privacy-policy.html` and capture a full-page screenshot, which completed successfully.
- Verified file changes and diffs with `git diff` / `git status` to ensure only the intended files (`tabletop-touchdown-privacy-policy.html` and `style.css`) were modified and the changes matched the formatting goals.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0b3f996d883299a9b3df63979928e)